### PR TITLE
publish on tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
   pull_request:
     branches:
       - 'master'
@@ -36,6 +38,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,format=long,prefix=
+            type=ref,event=tag
 
       - name: Build and push docker image
         uses: docker/build-push-action@v3

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ API Service for accessing runtime data
 # Install Air for auto reload when doing changes
 
 `go install github.com/cosmtrek/air@latest`
+
+# Releasing the insight-api
+To release the insight-api, follow these steps:
+
+1. Create a new tag in GitHub for the release. The tag should be in the format vX.Y.Z, where X, Y, and Z are the major, minor, and patch versions of the release, respectively.
+2. Push the tag to GitHub.
+3. Update the deployment-target-go with the new tag. To do this, edit the [insightsDeployment.yml](https://github.com/kapetacom/deployment-target-gcp-go/blob/427d013af3bd90b0fefc4ef04b92c860e96c3361/pkg/templates/insightsDeployment.yml#L32) file and replace the old tag with the new tag.
+4. Commit and push the changes to the deployment-target-go repository.
+
+The new release will be automatically deployed next time people are deploying.


### PR DESCRIPTION
that way we can in the deployer specify a version an not latest.
When using latest we are unable to force an upgrade since kubernetes has
no way of knowing there is a new version